### PR TITLE
Fixed Scene name for Da Vinci's Demons.

### DIFF
--- a/exceptions.txt
+++ b/exceptions.txt
@@ -246,7 +246,7 @@
 74372: 'Blue Planet',
 257804: 'Too Cute!',
 88631: 'Krod Mandoon',
-259669: 'DaVincis Demons', 'Vincis Demons', 'Vinci\'s Demons',
+259669: 'Da Vincis Demons',
 72449: 'Stargate SG1',
 264030: 'Avengers Assemble', 'Marvels Avengers Assemble',
 73893: 'Enterprise',


### PR DESCRIPTION
On the indexer the show is called `Da Vinci's Demons` i removed the 3 current exceptions for 1 working exception `Da Vincis Demons`. (without the comma) 
Tested on TPB and NZBIndex. Both find the episodes with the new name.
