### PR TITLE
Fixed Scene exception for TURN

### DIFF
--- a/exceptions.txt
+++ b/exceptions.txt
@@ -414,7 +414,7 @@
 292421: 'James Corden',
 276498: 'Raised By Wolves UK',
 290176: 'The Comedians US',
-272135: 'TURN Washingtons Spies',
+272135: 'TURN',
 294846: '8MMM',
 294973: 'Home Fires UK',
 295438: 'Shark UK',


### PR DESCRIPTION
The show on the indexer is called `TURN: Washington's Spies` however scene releases are called `TURN`. Also removed the exception `TURN Washington's Spies` as its not used by KAT and only a few uploaded episodes on Usenet.
