### PR TITLE
Add exception for Stephen Colbert's Late Show

### DIFF
--- a/exceptions.txt
+++ b/exceptions.txt
@@ -442,3 +442,4 @@
 83671: 'aandenes makt',
 274627: 'jakten paa kjaerligheten',
 300820: 'Adam soker eva', 'Adam soeker eva',
+289574: 'Stephen Colbert',


### PR DESCRIPTION
http://thetvdb.com/?tab=series&id=289574&lid=7

For example:
- `Stephen.Colbert.2015.09.21.Steph.Curry.HDTV.x264-BATV.mp4`
- `Late.Show.with.Stephen.Colbert.2015.09.21.Stephen.Curry.Ted.Cruz.Don.Henley.720p.CBS.WEBRip.AAC2.0.H264-monkee.mkv`
- `Stephen.Colbert.2015.09.17.Naomi.Watts.720p.HDTV.x264-BATV.mkv`

Without the exception, only the middle one gets processed, with the exception all 3 do...
